### PR TITLE
Fix issue #33 et #97 - DocumentReference

### DIFF
--- a/input/FHIR/StructureDefinition-esms-document-reference.json
+++ b/input/FHIR/StructureDefinition-esms-document-reference.json
@@ -36,7 +36,8 @@
       {
         "id": "DocumentReference.type",
         "path": "DocumentReference.type",
-        "min": 1
+        "min": 1,
+        "short" :"Si la ressource contient le document CDA portant les données de individu et la décision : Code =  « 57830-2 » de la nomenclature LOINC docTypeCodes, Display = Admission request Document. Si la ressource contient le document CDA portant l'évaluation : Code = « 51848-0 » de la nomenclature LOINC docTypeCodes, Display = « Evaluation note"
       },
       {
         "id": "titreDocu",

--- a/input/FHIR/StructureDefinition-esms-document-reference.json
+++ b/input/FHIR/StructureDefinition-esms-document-reference.json
@@ -25,12 +25,6 @@
             "severity": "warning",
             "human": "Le nom de la pièce jointe doit être  : \"Document Individu et décision\" ou \"Document évaluation\"",
             "expression": "content.attachment.title='Document Individu et décision' or content.attachment.title='Document évaluation'"
-          },
-          {
-            "key": "regle-Contenu",
-            "severity": "error",
-            "human": "Le transport des données est obligatoire, le champ data doit être rempli",
-            "expression": "content.attachment.data.exists()"
           }
         ]
       },

--- a/input/FHIR/StructureDefinition-sdo-document-reference.json
+++ b/input/FHIR/StructureDefinition-sdo-document-reference.json
@@ -17,6 +17,18 @@
 	"differential": {
 		"element": [
 			{
+				"id": "DocumentReference",
+				"path": "DocumentReference",
+				"constraint": [
+				  {
+					"key": "regle-Contenu",
+					"severity": "error",
+					"human": "Le transport des données est obligatoire, le champ data doit être rempli",
+					"expression": "content.attachment.data.exists()"
+				  }
+				]
+			  },
+			{
 				"id": "DocumentReference.identifier",
 				"path": "DocumentReference.identifier",
 				"min": 1,
@@ -26,12 +38,8 @@
 				"id": "DocumentReference.content",
 				"path": "DocumentReference.content",
 				"max": "1"
-			},
-			{
-				"id": "DocumentReference.type",
-				"path": "DocumentReference.type",
-				"short": "Si la ressource contient le document CDA portant les données de individu et la décision : Code =  « 57830-2 » de la nomenclature LOINC docTypeCodes, Display = Admission request Document. Si la ressource contient le document CDA portant l'évaluation : Code = « 51848-0 » de la nomenclature LOINC docTypeCodes, Display = « Evaluation note »"
 			}
+	
 		]
 	}
 }

--- a/input/FHIR/StructureDefinition-sdo-document-reference.json
+++ b/input/FHIR/StructureDefinition-sdo-document-reference.json
@@ -23,7 +23,7 @@
 				  {
 					"key": "regle-Contenu",
 					"severity": "warning",
-					"human": "Le transport des données est obligatoire, le champ data doit être rempli",
+					"human": "Le transport des données devient obligatoire lorsque la ressource complète est transportée, le champs data doit alors être rempli",
 					"expression": "content.attachment.data.exists()"
 				  }
 				]

--- a/input/FHIR/StructureDefinition-sdo-document-reference.json
+++ b/input/FHIR/StructureDefinition-sdo-document-reference.json
@@ -22,7 +22,7 @@
 				"constraint": [
 				  {
 					"key": "regle-Contenu",
-					"severity": "error",
+					"severity": "warning",
 					"human": "Le transport des données est obligatoire, le champ data doit être rempli",
 					"expression": "content.attachment.data.exists()"
 				  }


### PR DESCRIPTION
Ajout de la règle de gestion pour vérifier qu'il y a ai content.attachement.data, et suppression contraintes sur attribut type. Suppression de la règle coté ESMS car hérité de SDO