### PR TITLE
ANS-006-113 - Update dépendances NOS

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -12,7 +12,7 @@ version: 4.0.2 # shall conforms to Semantic Versioning https://fr.wiktionary.org
 fhirVersion: 4.0.1
 copyrightYear: 2023+
 dependencies:
-    ans.fr.nos: 1.2.0
+    ans.fr.nos: latest
 releaseLabel: trial-use
 jurisdiction: urn:iso:std:iso:3166#FR "FRANCE"
 


### PR DESCRIPTION


## Description des changements

Passage d'une version statique vers la dernière version publiée via #latest


## Preview

https://ansforge.github.io/IG-fhir-medicosocial-suivi-decisions-orientation/158-nos-gérer-les-dépendances-nos-en-current-ou-maj-du-package-manuel/ig
