### PR TITLE
ANS-006-133 - Exemple CDA - Corriger la position de certains éléments #191

### DIFF
--- a/input/images/CDA_SI-ESMS_Decision.xml
+++ b/input/images/CDA_SI-ESMS_Decision.xml
@@ -25,17 +25,18 @@
     <title>Exemple ESMS Décision</title>
     <effectiveTime value="20230110"/>
     <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" codeSystemName="Confidentiality" displayName="Normal"/>
+    <languageCode code="fr-FR" />
     <setId root="492BB602-B08C-11EE-A506-0242AC120002" extension="01"/>
 	<!-- Deuxième version du document -->
 	<versionNumber value="2"/>
-	<languageCode code="fr-FR" />
+
     
     <!-- Identité de l'individu et mesure de protection  -->
     <recordTarget>
         <patientRole>
             <!-- INS-NIR de production : 1.2.250.1.213.1.4.8 -->
-            <id extension="idDossierIndividu" root="1.2.250.1.213.7.14"/>
             <id extension="276059205062865" root="1.2.250.1.213.1.4.8"/>
+            <id extension="idDossierIndividu" root="1.2.250.1.213.7.14"/>
 			<!-- Adresse -->
             <addr use="PHYS">
                 <streetAddressLine>17 AV de Bruxelles</streetAddressLine>

--- a/input/images/CDA_SI-ESMS_Decision.xml
+++ b/input/images/CDA_SI-ESMS_Decision.xml
@@ -36,6 +36,7 @@
         <patientRole>
             <!-- INS-NIR de production : 1.2.250.1.213.1.4.8 -->
             <id extension="276059205062865" root="1.2.250.1.213.1.4.8"/>
+            <!-- Identifiant initial au sein de la MDPH ayant créé le dossier individu -->
             <id extension="idDossierIndividu" root="1.2.250.1.213.7.14"/>
 			<!-- Adresse -->
             <addr use="PHYS">

--- a/input/images/CDA_SI-ESMS_Evaluation.xml
+++ b/input/images/CDA_SI-ESMS_Evaluation.xml
@@ -23,15 +23,16 @@
     <title>Exemple ESMS Evaluation</title>
     <effectiveTime value="20230110"/>
     <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" codeSystemName="Confidentiality" displayName="Normal"/>
-	<setId root="492BB602-B08C-11EE-A506-0242AC120002" extension="02"/>
+	<languageCode code="fr-FR" />
+    <setId root="492BB602-B08C-11EE-A506-0242AC120002" extension="02"/>
 	<versionNumber value="2"/>
-    <languageCode code="fr-FR" />
+
     
     <recordTarget>
         <patientRole>
             <!-- INS-NIR de production : 1.2.250.1.213.1.4.8 -->
-            <id extension="idDossierIndividu" root="1.2.250.1.213.7.14"/>
             <id extension="276059205062865" root="1.2.250.1.213.1.4.8"/>
+            <id extension="idDossierIndividu" root="1.2.250.1.213.7.14"/>
             <!-- Adresse -->
             <addr use="PHYS">
                 <streetAddressLine>17 AV de Bruxelles</streetAddressLine>

--- a/input/images/CDA_SI-ESMS_Evaluation.xml
+++ b/input/images/CDA_SI-ESMS_Evaluation.xml
@@ -32,6 +32,7 @@
         <patientRole>
             <!-- INS-NIR de production : 1.2.250.1.213.1.4.8 -->
             <id extension="276059205062865" root="1.2.250.1.213.1.4.8"/>
+            <!-- Identifiant initial au sein de la MDPH ayant créé le dossier individu-->
             <id extension="idDossierIndividu" root="1.2.250.1.213.7.14"/>
             <!-- Adresse -->
             <addr use="PHYS">


### PR DESCRIPTION
## Description des changements

Déplacements des éléments suivants dans les fichiers CDA_SI-ESMS_Evaluation.xml et CDA_SI-ESMS_Decision.xml :

- L'élément languageCode a été positionné avant le setId et le versionNumber ;
- Le NIR a été positionné avant l'identifiant de dossier.

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-suivi-decisions-orientation/Exemple_CDA-Correction_Position_Elements/ig
