### PR TITLE
ANS-006-133 - Contenu Dossier - MAJ idDocument - Ajout tableau contrainte RecordTarget

### DIFF
--- a/input/images/CDA_SI-ESMS_Decision.xml
+++ b/input/images/CDA_SI-ESMS_Decision.xml
@@ -20,7 +20,7 @@
     <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
     <templateId root="1.2.250.1.213.1.1.1.4.8"/>
 	<templateId root="2.16.840.1.113883.10.12.2"/>
-    <id root="492BB602-B08C-11EE-A506-0242AC120002" extension="002"/>
+    <id root="492BB602-B08C-11EE-A506-0242AC120002" extension="3141"/>
     <code code="18825-0" codeSystem="2.16.840.1.113883.4.642.3.240" displayName="Medical social services attachment"/>
     <title>Exemple ESMS Décision</title>
     <effectiveTime value="20230110"/>

--- a/input/images/CDA_SI-ESMS_Decision.xml
+++ b/input/images/CDA_SI-ESMS_Decision.xml
@@ -20,7 +20,7 @@
     <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
     <templateId root="1.2.250.1.213.1.1.1.4.8"/>
 	<templateId root="2.16.840.1.113883.10.12.2"/>
-    <id root="492BB602-B08C-11EE-A506-0242AC120002" extension="3141"/>
+    <id root="492BB602-B08C-11EE-A506-0242AC120002" extension="idNat_Decision"/>
     <code code="18825-0" codeSystem="2.16.840.1.113883.4.642.3.240" displayName="Medical social services attachment"/>
     <title>Exemple ESMS Décision</title>
     <effectiveTime value="20230110"/>

--- a/input/images/CDA_SI-ESMS_Evaluation.xml
+++ b/input/images/CDA_SI-ESMS_Evaluation.xml
@@ -18,7 +18,7 @@
     <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
     <templateId root="1.2.250.1.213.1.1.1.4.9"/>
     <templateId root="2.16.840.1.113883.10.12.2"/>
-    <id root="492BB602-B08C-11EE-A506-0242AC120002" extension="3141"/>
+    <id root="450BB904-D02B-22AE-B605-1593BC475964" extension="idNat_Decision"/>
     <code code="18825-0" codeSystem="2.16.840.1.113883.4.642.3.240" displayName="Medical social services attachment"/>
     <title>Exemple ESMS Evaluation</title>
     <effectiveTime value="20230110"/>

--- a/input/images/CDA_SI-ESMS_Evaluation.xml
+++ b/input/images/CDA_SI-ESMS_Evaluation.xml
@@ -18,7 +18,7 @@
     <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
     <templateId root="1.2.250.1.213.1.1.1.4.9"/>
     <templateId root="2.16.840.1.113883.10.12.2"/>
-    <id root="492BB602-B08C-11EE-A506-0242AC120002" extension="009"/>
+    <id root="492BB602-B08C-11EE-A506-0242AC120002" extension="3141"/>
     <code code="18825-0" codeSystem="2.16.840.1.113883.4.642.3.240" displayName="Medical social services attachment"/>
     <title>Exemple ESMS Evaluation</title>
     <effectiveTime value="20230110"/>

--- a/input/pagecontent/contenu_dossier.md
+++ b/input/pagecontent/contenu_dossier.md
@@ -146,11 +146,12 @@ Ce volet décrit le contenu de 2 documents CDA différents :
                 <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:left;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:  black;"></span></p>
             </td>
             <td style="width: 184.25pt;border-width: medium 1pt 1pt medium;border-style: none solid solid none;border-color: currentcolor windowtext windowtext currentcolor;padding: 0cm 5.4pt;vertical-align: top;">
-                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">Identifiant unique du document</span></p>
+                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">Identifiant unique du document.</span></p>
+                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:#C00000;">Attribut nullFlavor interdit.</span></p>
                 <div style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'>
                     <ul style="margin-bottom:0cm;list-style-type: disc;margin-left:8px;">
-                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@extension = valeur d&rsquo;un identifiant unique attribu&eacute; par le syst&egrave;me d&rsquo;information &eacute;metteur. Il permet d&rsquo;identifier chaque instance et version des documents.</span></li>
-                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@root =&nbsp;</span><span style="color:black;">racine d&rsquo;OID commune aux instances des documents d&rsquo;une structure &eacute;mettrice. <br>
+                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@extension = valeur de l&rsquo;idNat_Decision.</span></li>
+                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@root =&nbsp;</span><span style="color:black;">valeur d&rsquo;un OID propre &agrave; l&rsquo;emetteur. L&rsquo;OID form&eacute; doit &ecirc;tre complet et permettra d&rsquo;identifier l&rsquo;instance du document. <br>
                         Il est recommand&eacute; de g&eacute;n&eacute;rer une racine d&rsquo;OID pour chaque structure, &agrave; partir du g&eacute;n&eacute;rateur </span><a href="https://www.uuidgenerator.net/version1"><span style="color:#00B0F0;">https://www.uuidgenerator.net/version1</span></a>. L'OID obtenu devra être converti en majuscule afin de se conformer aux spécifications HL7</li>
                     </ul>
                 </div>
@@ -1000,6 +1001,40 @@ Cette section présente le contenu de l'en-tête du document CDA. On y retrouve 
 </table>
 
 #### RecordTarget
+
+##### Contraintes spécifiques au document portant la Décision ou l'Evaluation
+Le tableau de contraintes présenté ci-dessous offre une vue d'ensemble des exigences spécifiques à respecter pour chaque type de document, qu'il s'agisse d'une Décision ou d'une Évaluation :
+
+<table style="width: 5.5e+2pt;border-collapse:collapse;border:none;">
+    <tbody>
+        <tr>
+            <td style="width:43.6pt;border:solid windowtext 1.0pt;background:#7B7B7B;padding:0cm 5.4pt 0cm 5.4pt;">
+                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:center;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><strong><span style="color:white;">El&eacute;ment XML</span></strong></p>
+            </td>
+            <td style="width:43.6pt;border:solid windowtext 1.0pt;border-left:  none;background:#7B7B7B;padding:0cm 5.4pt 0cm 5.4pt;">
+                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:center;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><strong><span style="color:white;">D&eacute;cision</span></strong></p>
+            </td>
+            <td style="width: 43.6pt;border-width: 1pt 1pt 1pt medium;border-style: solid solid solid none;border-color: windowtext windowtext windowtext currentcolor;border-image: none;background: rgb(123, 123, 123);padding: 0cm 5.4pt;vertical-align: top;">
+                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:center;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><strong><span style="color:white;">Evaluation</span></strong></p>
+            </td>
+        </tr>
+        <tr>
+            <td style="width:43.6pt;border:solid windowtext 1.0pt;border-top:  none;padding:0cm 5.4pt 0cm 5.4pt;">
+                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:center;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">recordTarget.patientRole.patient</span></p>
+            </td>
+            <td style="width:43.6pt;border-top:none;border-left:none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;">
+                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:left;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:  black;">Obligatoire [1..1]</span></p>
+            </td>
+            <td style="width:43.6pt;border-top:none;border-left:none;border-bottom:  solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;">
+                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:center;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">Facultatif [0..1]</span></p>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+##### Contenu des éléments du Recordtarget
+Le détail du contenu des éléments associés au RecordTarget est spécifié dans le tableau ci-dessous :
+
 <table style="width: 5.6e+2pt;margin-left:-14.45pt;border-collapse:collapse;border:none;">
     <thead>
         <tr>

--- a/input/pagecontent/contenu_dossier.md
+++ b/input/pagecontent/contenu_dossier.md
@@ -150,9 +150,8 @@ Ce volet décrit le contenu de 2 documents CDA différents :
                 <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:#C00000;">Attribut nullFlavor interdit.</span></p>
                 <div style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'>
                     <ul style="margin-bottom:0cm;list-style-type: disc;margin-left:8px;">
+                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@root (obligatoire) =&nbsp;</span><span style="color:black;">valeur d&rsquo;un OID propre &agrave; l&rsquo;emetteur. L&rsquo;OID form&eacute; doit &ecirc;tre complet et permettra d&rsquo;identifier l&rsquo;instance du document. <br></li>
                         <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@extension = valeur de l&rsquo;idNat_Decision.</span></li>
-                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@root =&nbsp;</span><span style="color:black;">valeur d&rsquo;un OID propre &agrave; l&rsquo;emetteur. L&rsquo;OID form&eacute; doit &ecirc;tre complet et permettra d&rsquo;identifier l&rsquo;instance du document. <br>
-                        Il est recommand&eacute; de g&eacute;n&eacute;rer une racine d&rsquo;OID pour chaque structure, &agrave; partir du g&eacute;n&eacute;rateur </span><a href="https://www.uuidgenerator.net/version1"><span style="color:#00B0F0;">https://www.uuidgenerator.net/version1</span></a>. L'OID obtenu devra être converti en majuscule afin de se conformer aux spécifications HL7</li>
                     </ul>
                 </div>
             </td>
@@ -543,13 +542,12 @@ Ce volet décrit le contenu de 2 documents CDA différents :
                 <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:left;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:  black;"></span></p>
             </td>
             <td style="width: 184.25pt;border-width: medium 1pt 1pt medium;border-style: none solid solid none;border-color: currentcolor windowtext windowtext currentcolor;padding: 0cm 5.4pt;vertical-align: top;">
-                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">Identifiant unique du document</span></p>
+                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">Identifiant unique du document.</span></p>
+                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:#C00000;">Attribut nullFlavor interdit.</span></p>
                 <div style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'>
                     <ul style="margin-bottom:0cm;list-style-type: disc;margin-left:8px;">
-                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@extension = valeur d&rsquo;un identifiant unique attribu&eacute; par le syst&egrave;me d&rsquo;information &eacute;metteur. Il permet d&rsquo;identifier chaque instance et version des documents.</span></li>
-                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:left;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@root =&nbsp;</span><span style="color:black;">racine d&rsquo;OID commune aux instances des documents d&rsquo;une structure &eacute;mettrice. <br>
-                        Il est recommand&eacute; de g&eacute;n&eacute;rer une racine d&rsquo;OID pour chaque structure, &agrave; partir du g&eacute;n&eacute;rateur </span><a href="https://www.uuidgenerator.net/version1"><span style="color:#00B0F0;">https://www.uuidgenerator.net/version1</span></a>. L'OID obtenu devra être converti en majuscule afin de se conformer aux spécifications HL7
-                        </li>
+                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@root (obligatoire) =&nbsp;</span><span style="color:black;">valeur d&rsquo;un OID propre &agrave; l&rsquo;emetteur. L&rsquo;OID form&eacute; doit &ecirc;tre complet et permettra d&rsquo;identifier l&rsquo;instance du document. <br></li>
+                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@extension = valeur de l&rsquo;idNat_Decision.</span></li>
                     </ul>
                 </div>
             </td>
@@ -1003,7 +1001,7 @@ Cette section présente le contenu de l'en-tête du document CDA. On y retrouve 
 #### RecordTarget
 
 ##### Contraintes spécifiques au document portant la Décision ou l'Evaluation
-Le tableau de contraintes présenté ci-dessous offre une vue d'ensemble des exigences spécifiques à respecter pour chaque type de document, qu'il s'agisse d'une Décision ou d'une Évaluation :
+<p>Le tableau de contraintes pr&eacute;sent&eacute; ci-dessous offre une vue d&rsquo;ensemble des exigences sp&eacute;cifiques &agrave; respecter pour chaque type de document, qu&rsquo;il s&rsquo;agisse d&rsquo;une D&eacute;cision ou d&rsquo;une &Eacute;valuation :</p>
 
 <table style="width: 5.5e+2pt;border-collapse:collapse;border:none;">
     <tbody>
@@ -1033,7 +1031,7 @@ Le tableau de contraintes présenté ci-dessous offre une vue d'ensemble des exi
 </table>
 
 ##### Contenu des éléments du Recordtarget
-Le détail du contenu des éléments associés au RecordTarget est spécifié dans le tableau ci-dessous :
+<p>Le détail du contenu des &eacute;l&eacute;ments associ&eacute;s au RecordTarget est sp&eacute;cifi&eacute; dans le tableau ci-dessous :</p>
 
 <table style="width: 5.6e+2pt;margin-left:-14.45pt;border-collapse:collapse;border:none;">
     <thead>

--- a/input/pagecontent/contenu_dossier.md
+++ b/input/pagecontent/contenu_dossier.md
@@ -150,8 +150,8 @@ Ce volet décrit le contenu de 2 documents CDA différents :
                 <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:#C00000;">Attribut nullFlavor interdit.</span></p>
                 <div style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'>
                     <ul style="margin-bottom:0cm;list-style-type: disc;margin-left:8px;">
-                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@root (obligatoire) =&nbsp;</span><span style="color:black;">valeur d&rsquo;un OID propre &agrave; l&rsquo;emetteur. L&rsquo;OID form&eacute; doit &ecirc;tre complet et permettra d&rsquo;identifier l&rsquo;instance du document. <br></li>
-                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@extension = valeur de l&rsquo;idNat_Decision.</span></li>
+                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@root (obligatoire) = valeur d'un OID propre à l'emetteur. L'OID formé doit être complet et permettra d'identifier l'instance du document. </span></li>
+                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@extension (obligatoire) = valeur de l'idNat_Decision.</span></li>
                     </ul>
                 </div>
             </td>
@@ -546,8 +546,8 @@ Ce volet décrit le contenu de 2 documents CDA différents :
                 <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:#C00000;">Attribut nullFlavor interdit.</span></p>
                 <div style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'>
                     <ul style="margin-bottom:0cm;list-style-type: disc;margin-left:8px;">
-                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@root (obligatoire) =&nbsp;</span><span style="color:black;">valeur d&rsquo;un OID propre &agrave; l&rsquo;emetteur. L&rsquo;OID form&eacute; doit &ecirc;tre complet et permettra d&rsquo;identifier l&rsquo;instance du document. <br></li>
-                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@extension = valeur de l&rsquo;idNat_Decision.</span></li>
+                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@root (obligatoire) = valeur d'un OID propre à l'emetteur. L'OID formé doit être complet et permettra d'identifier l'instance du document.</span></li>
+                        <li style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:justify;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">@extension (obligatoire) = valeur de l'idNat_Decision.</span></li>
                     </ul>
                 </div>
             </td>
@@ -1001,37 +1001,14 @@ Cette section présente le contenu de l'en-tête du document CDA. On y retrouve 
 #### RecordTarget
 
 ##### Contraintes spécifiques au document portant la Décision ou l'Evaluation
-<p>Le tableau de contraintes pr&eacute;sent&eacute; ci-dessous offre une vue d&rsquo;ensemble des exigences sp&eacute;cifiques &agrave; respecter pour chaque type de document, qu&rsquo;il s&rsquo;agisse d&rsquo;une D&eacute;cision ou d&rsquo;une &Eacute;valuation :</p>
+Le tableau de contraintes présenté ci-dessous offre une vue d'ensemble des exigences spéifiques à respecter pour chaque type de document, qu'il s'agisse d'une Décision ou d'une Evaluation :
 
-<table style="width: 5.5e+2pt;border-collapse:collapse;border:none;">
-    <tbody>
-        <tr>
-            <td style="width:43.6pt;border:solid windowtext 1.0pt;background:#7B7B7B;padding:0cm 5.4pt 0cm 5.4pt;">
-                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:center;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><strong><span style="color:white;">El&eacute;ment XML</span></strong></p>
-            </td>
-            <td style="width:43.6pt;border:solid windowtext 1.0pt;border-left:  none;background:#7B7B7B;padding:0cm 5.4pt 0cm 5.4pt;">
-                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:center;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><strong><span style="color:white;">D&eacute;cision</span></strong></p>
-            </td>
-            <td style="width: 43.6pt;border-width: 1pt 1pt 1pt medium;border-style: solid solid solid none;border-color: windowtext windowtext windowtext currentcolor;border-image: none;background: rgb(123, 123, 123);padding: 0cm 5.4pt;vertical-align: top;">
-                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:center;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><strong><span style="color:white;">Evaluation</span></strong></p>
-            </td>
-        </tr>
-        <tr>
-            <td style="width:43.6pt;border:solid windowtext 1.0pt;border-top:  none;padding:0cm 5.4pt 0cm 5.4pt;">
-                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:center;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">recordTarget.patientRole.patient</span></p>
-            </td>
-            <td style="width:43.6pt;border-top:none;border-left:none;border-bottom:solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;">
-                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:left;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:  black;">Obligatoire [1..1]</span></p>
-            </td>
-            <td style="width:43.6pt;border-top:none;border-left:none;border-bottom:  solid windowtext 1.0pt;border-right:solid windowtext 1.0pt;padding:0cm 5.4pt 0cm 5.4pt;">
-                <p style='margin-top:0cm;margin-right:0cm;margin-bottom:6.0pt;margin-left:0cm;text-align:center;line-height:115%;font-size:13px;font-family:"Arial",sans-serif;'><span style="color:black;">Facultatif [0..1]</span></p>
-            </td>
-        </tr>
-    </tbody>
-</table>
+| Eléments XML | Décision | Evaluation |
+| --- | --- | --- |
+| recordTarget.patientRole.patient | Obligatoire [1..1] | Facultatif [0..1] |
 
 ##### Contenu des éléments du Recordtarget
-<p>Le détail du contenu des &eacute;l&eacute;ments associ&eacute;s au RecordTarget est sp&eacute;cifi&eacute; dans le tableau ci-dessous :</p>
+Le détail du contenu des éléments associés au RecordTarget est spécifié dans le tableau ci-dessous :
 
 <table style="width: 5.6e+2pt;margin-left:-14.45pt;border-collapse:collapse;border:none;">
     <thead>


### PR DESCRIPTION
## Description des changements

*Issue n° 160 :
 
Identifiant unique du document.

Attribut nullFlavor interdit.

@root = valeur d’un OID propre à l’emetteur. L’OID formé doit être complet et permettra d’identifier l’instance du document.
@extension = valeur de l’idNat_Decision. 

Remplace l'actuel fonctionnement :

@root = racine d’OID commune aux instances des documents d’une structure émettrice. 
@extension = valeur d’un identifiant unique attribué par le système d’information émetteur. Il permet d’identifier chaque instance et version des documents.

Changements également dans les exemples CDA

* Issue n°159 :

Ajout d'un tableau pour préciser les contraintes entre Décision et Evaluation pour le recordTarget


## Preview

https://ansforge.github.io/IG-fhir-medicosocial-suivi-decisions-orientation/Contenu_Dossier_159_160/ig
