### PR TITLE
feat: adopt container mode for CI-build workflow

### DIFF
--- a/.github/workflows/fhir-worklows.yml
+++ b/.github/workflows/fhir-worklows.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   run-sushi-tests_gitHubPages:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ansforge/fhir-ig-builder:latest
     steps:
       - uses: actions/checkout@v3
         with:      
@@ -20,4 +22,5 @@ jobs:
           validator_cli: "false"
           generate_testscript: "false"
           generate_plantuml : "false"
+          container_mode: "true"
 #          ig-publisher-version: 2.0.16


### PR DESCRIPTION
## Description des changements

* Adoption du mode container pour le workflow CI-build
* Ajout de la directive `container: ghcr.io/ansforge/fhir-ig-builder:latest` sur le job
* Ajout de `container_mode: "true"` dans les inputs de l'action IG-workflows

Ce changement permet d'utiliser l'image Docker pré-configurée avec SUSHI, les packages FHIR courants et le publisher JAR, réduisant le temps de build d'environ 18%.

## Type de changement

- [ ] Nouveau contenu (profil, extension, page, exemple)
- [ ] Correction (erreur dans un profil, une page, une dépendance)
- [x] Refactoring (pas de changement fonctionnel)
- [ ] Release

## Checklist

- [ ] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement
- [ ] `change-log.md` mis à jour
- [ ] La branche est à jour avec `main`

## Preview

https://ansforge.github.io/IG-fhir-medicosocial-suivi-decisions-orientation/feat/container-mode/ig